### PR TITLE
Attempt to fix the indentation issue

### DIFF
--- a/resources/scripts/codemirror.js
+++ b/resources/scripts/codemirror.js
@@ -316,6 +316,7 @@ if ( !String.prototype.includes ) {
 			matchBrackets: true,
 			viewportMargin: 5000,
 			indentWithTabs: indentmode,
+			indentUnit: 4,
 			extraKeys: {
 				F11: function( cm ) {
 					cm.setOption( 'fullScreen', !cm.getOption( 'fullScreen' ) );


### PR DESCRIPTION
A mix of 4 spaces that a tabs will replaces (4 is default value of tabSize option) and 2 spaces are made when making an indent (2 is default value of indentUnit option) seems to be the cause of the indentation issues.  

Tested in browser's js debugging and had the expected outcome. 