### PR TITLE
LPA-6078 add dark-theme

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
 		"es-x/no-string-prototype-startswith": "off",
 		"es-x/no-string-prototype-endswith": "off",
 		"es-x/no-string-prototype-includes": "off",
-		"es-x/no-array-prototype-includes": "off"
+		"es-x/no-array-prototype-includes": "off",
+		"mediawiki/no-nodelist-unsupported-methods": "off"
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,10 @@
 		"no-restricted-properties": "off",
 		"no-restricted-syntax": "off",
 		"no-extend-native": "off",
-		"no-shadow": "off"
+		"no-shadow": "off",
+		"es-x/no-string-prototype-startswith": "off",
+		"es-x/no-string-prototype-endswith": "off",
+		"es-x/no-string-prototype-includes": "off",
+		"es-x/no-array-prototype-includes": "off"
 	}
 }

--- a/cm-library/codemirror-mode/mediawiki/mediawiki.css
+++ b/cm-library/codemirror-mode/mediawiki/mediawiki.css
@@ -2,32 +2,6 @@
 	block-closing-brace-space-after, declaration-block-single-line-max-declarations,
 	declaration-block-semicolon-newline-after, selector-list-comma-newline-after */
 
-.skin-lakesideview div.wikiEditor-ui .wikiEditor-ui-view {
-    border: 0;
-}
-
-.skin-lakesideview div.wikiEditor-ui-toolbar {
-    background-color: var( --clr-surface-4 );
-    color: var( --clr-on-surface );
-}
-
-.skin-lakesideview .CodeMirror {
-    background-color: var( --clr-surface );
-    color: var( --clr-on-surface );
-}
-
-.skin-lakesideview .CodeMirror-linenumber {
-    color: var( --clr-on-surface );
-}
-
-.skin-lakesideview .CodeMirror-gutters {
-    background-color: var( --clr-surface-1 );
-}
-
-.skin-lakesideview .CodeMirror-activeline-background {
-    background-color: var( --clr-surface-1 );
-}
-
 .cm-mw-pagename { text-decoration: underline; }
 
 .cm-mw-matching { background-color: #ffd700; }

--- a/cm-library/codemirror-mode/mediawiki/mediawiki.css
+++ b/cm-library/codemirror-mode/mediawiki/mediawiki.css
@@ -2,6 +2,55 @@
 	block-closing-brace-space-after, declaration-block-single-line-max-declarations,
 	declaration-block-semicolon-newline-after, selector-list-comma-newline-after */
 
+.skin-lakesideview div.wikiEditor-ui .wikiEditor-ui-view {
+    border: 0;
+}
+
+.skin-lakesideview div.wikiEditor-ui-toolbar {
+    background-color: var( --clr-surface-4 );
+    color: var( --clr-on-surface );
+}
+
+.skin-lakesideview .CodeMirror {
+    background-color: var( --clr-surface );
+    color: var( --clr-on-surface );
+}
+
+.skin-lakesideview .CodeMirror-linenumber {
+    color: var( --clr-on-surface );
+}
+
+.skin-lakesideview .CodeMirror-gutters {
+    background-color: var( --clr-surface-1 );
+}
+
+.skin-lakesideview .CodeMirror-activeline-background {
+    background-color: var( --clr-surface-1 );
+}
+
+/* Overwrite classes from codemirror.css */
+.theme--dark .cm-mw-template-name {
+    color: #FF871F;
+}
+
+.theme--dark .cm-mw-template-bracket {
+    color: #FF75FF;
+}
+
+.theme--dark .cm-mw-template-argument-name {
+    color: #FF8585;
+}
+
+.theme--dark .cm-mw-template {
+    color: #58B0EE;
+}
+
+.theme--dark .cm-mw-template-delimiter {
+    color: #95A0F3;
+}
+
+/* End overwrite classes from codemirror.css */
+
 .cm-mw-pagename { text-decoration: underline; }
 
 .cm-mw-matching { background-color: #ffd700; }
@@ -29,15 +78,41 @@ pre.cm-mw-section-6 { font-weight: bold; }
 .cm-mw-template-delimiter { color: #80c; font-weight: bold; }
 .cm-mw-template-bracket { color: #80c; font-weight: bold; }
 
+/* Orange links */
+.theme--dark .cm-mw-templatevariable,
+.theme--dark .cm-mw-templatevariable-name,
+.theme--dark .cm-mw-templatevariable-bracket,
+.theme--dark .cm-mw-templatevariable-delimiter {
+    color: #FF871F;
+}
+
 .cm-mw-templatevariable { color: #f50; font-weight: normal; }
 .cm-mw-templatevariable-name { color: #f50; font-weight: bold; }
 .cm-mw-templatevariable-bracket { color: #f50; font-weight: normal; }
 .cm-mw-templatevariable-delimiter { color: #f50; font-weight: bold; }
 
+/* Red links */
+.theme--dark .cm-mw-parserfunction-name,
+.theme--dark .cm-mw-parserfunction-bracket,
+.theme--dark .cm-mw-parserfunction-delimiter {
+    color: #FF8585;
+}
+
 .cm-mw-parserfunction { font-weight: normal; }
 .cm-mw-parserfunction-name { color: #a11; font-weight: bold; }
 .cm-mw-parserfunction-bracket { color: #a11; font-weight: bold; }
 .cm-mw-parserfunction-delimiter { color: #a11; font-weight: bold; }
+
+
+/* Green links */
+.theme--dark .cm-mw-exttag-name,
+.theme--dark .cm-mw-exttag-bracket,
+.theme--dark .cm-mw-exttag-attribute,
+.theme--dark .cm-mw-htmltag-name,
+.theme--dark .cm-mw-htmltag-bracket,
+.theme--dark .cm-mw-htmltag-attribute {
+    color: #2CCC00;
+}
 
 pre.cm-mw-exttag { background-image: url( img/ext2.png ); }
 .cm-mw-exttag { background-image: url( img/ext4.png ); }
@@ -52,6 +127,21 @@ pre.cm-mw-exttag { background-image: url( img/ext2.png ); }
 pre.cm-mw-tag-pre, .cm-mw-tag-pre { background-image: url( img/black4.png ); }
 pre.cm-mw-tag-nowiki, .cm-mw-tag-nowiki { background-image: url( img/black4.png ); }
 
+/* Blue links */
+.theme--dark .cm-mw-link,
+.theme--dark .cm-mw-link-pagename,
+.theme--dark .cm-mw-link-bracket,
+.theme--dark .cm-mw-link-delimiter,
+.theme--dark .cm-mw-extlink, .theme--dark .cm-mw-free-extlink,
+.theme--dark .cm-mw-extlink-protocol, .theme--dark .cm-mw-free-extlink-protocol,
+.theme--dark .cm-mw-extlink-bracket {
+    color: #89A7E1;
+}
+
+.theme--dark .cm-mw-link-tosection {
+    color: #5DADF4;
+}
+
 .cm-mw-link { color: #36c; font-weight: normal; }
 .cm-mw-link-pagename { color: #36c; font-weight: normal; }
 .cm-mw-link-tosection { color: #18e; font-weight: normal; }
@@ -63,6 +153,13 @@ pre.cm-mw-tag-nowiki, .cm-mw-tag-nowiki { background-image: url( img/black4.png 
 .cm-mw-extlink-protocol, .cm-mw-free-extlink-protocol { color: #36c; font-weight: bold; }
 /* .cm-mw-extlink-text { } */
 .cm-mw-extlink-bracket { color: #36c; font-weight: bold; }
+
+/* Pink links */
+.theme--dark .cm-mw-table-bracket,
+.theme--dark .cm-mw-table-delimiter,
+.theme--dark .cm-mw-table-definition {
+    color: #FF75FF;
+}
 
 .cm-mw-table-bracket { color: #e0e; font-weight: bold; }
 .cm-mw-table-delimiter { color: #e0e; font-weight: bold; }

--- a/cm-library/codemirror-mode/mediawiki/mediawiki.css
+++ b/cm-library/codemirror-mode/mediawiki/mediawiki.css
@@ -28,29 +28,6 @@
     background-color: var( --clr-surface-1 );
 }
 
-/* Overwrite classes from codemirror.css */
-.theme--dark .cm-mw-template-name {
-    color: #FF871F;
-}
-
-.theme--dark .cm-mw-template-bracket {
-    color: #FF75FF;
-}
-
-.theme--dark .cm-mw-template-argument-name {
-    color: #FF8585;
-}
-
-.theme--dark .cm-mw-template {
-    color: #58B0EE;
-}
-
-.theme--dark .cm-mw-template-delimiter {
-    color: #95A0F3;
-}
-
-/* End overwrite classes from codemirror.css */
-
 .cm-mw-pagename { text-decoration: underline; }
 
 .cm-mw-matching { background-color: #ffd700; }

--- a/resources/styles/codemirror.css
+++ b/resources/styles/codemirror.css
@@ -27,9 +27,17 @@
 	font-weight: bold;
 }
 
+.theme--dark .cm-mw-template-bracket {
+	color: #FF75FF;
+}
+
 .cm-mw-template-name {
 	color: #e66c00;
 	font-weight: bold;
+}
+
+.theme--dark .cm-mw-template-name {
+	color: #FF871F;
 }
 
 .cm-mw-template-delimiter {
@@ -37,14 +45,26 @@
 	font-weight: bold;
 }
 
+.theme--dark .cm-mw-template-delimiter {
+	color: #95A0F3;
+}
+
 .cm-mw-template-argument-name {
 	color: #ff0000;
 	font-weight: bold;
 }
 
+.theme--dark .cm-mw-template-argument-name {
+	color: #FF8585;
+}
+
 .cm-mw-template {
 	color: #1169aa;
 	font-weight: normal;
+}
+
+.theme--dark .cm-mw-template {
+	color: #58B0EE;
 }
 
 .wikiEditor-ui .options {

--- a/resources/styles/codemirror.css
+++ b/resources/styles/codemirror.css
@@ -6,6 +6,8 @@
 	height: 600px;
 	font-family: 'Source Code Pro', monospace;
 	font-size: 13px;
+	background-color: var( --clr-surface );
+	color: var( --clr-on-surface );
 }
 
 .cm-mw-htmltag-attribute {
@@ -28,7 +30,7 @@
 }
 
 .theme--dark .cm-mw-template-bracket {
-	color: #FF75FF;
+	color: #ff75ff;
 }
 
 .cm-mw-template-name {
@@ -37,7 +39,7 @@
 }
 
 .theme--dark .cm-mw-template-name {
-	color: #FF871F;
+	color: #ff871f;
 }
 
 .cm-mw-template-delimiter {
@@ -46,7 +48,7 @@
 }
 
 .theme--dark .cm-mw-template-delimiter {
-	color: #95A0F3;
+	color: #95a0f3;
 }
 
 .cm-mw-template-argument-name {
@@ -55,7 +57,7 @@
 }
 
 .theme--dark .cm-mw-template-argument-name {
-	color: #FF8585;
+	color: #ff8585;
 }
 
 .cm-mw-template {
@@ -64,11 +66,15 @@
 }
 
 .theme--dark .cm-mw-template {
-	color: #58B0EE;
+	color: #58b0ee;
 }
 
 .wikiEditor-ui .options {
 	z-index: 10000;
+}
+
+div.wikiEditor-ui .wikiEditor-ui-view {
+	border-color: var( --clr-border );
 }
 
 .CodeMirror.lineWrapping pre {
@@ -77,11 +83,25 @@
 	word-break: normal;
 }
 
-.wikiEditor-ui-toolbar .group .tool-select .options {
+div.wikiEditor-ui-toolbar {
+	background-color: var( --clr-surface-4 );
+	color: var( --clr-on-surface );
+}
+
+div.wikiEditor-ui-toolbar .group .tool-select .options {
 	/* stylelint-disable-next-line declaration-no-important */
 	z-index: 100 !important;
 }
 
+.CodeMirror-activeline-background {
+	background-color: var( --clr-surface-1 );
+}
+
 .CodeMirror-linenumber {
 	cursor: pointer;
+	color: var( --clr-on-surface );
+}
+
+.CodeMirror-gutters {
+	background-color: var( --clr-surface-1 );
 }

--- a/resources/styles/codemirror.css
+++ b/resources/styles/codemirror.css
@@ -6,8 +6,8 @@
 	height: 600px;
 	font-family: 'Source Code Pro', monospace;
 	font-size: 13px;
-	background-color: var( --clr-surface );
-	color: var( --clr-on-surface );
+	background-color: var( --clr-surface, #ffffff );
+	color: var( --clr-on-surface, #000000 );
 }
 
 .cm-mw-htmltag-attribute {
@@ -74,7 +74,7 @@
 }
 
 div.wikiEditor-ui .wikiEditor-ui-view {
-	border-color: var( --clr-border );
+	border-color: var( --clr-border, #c8ccd1 );
 }
 
 .CodeMirror.lineWrapping pre {
@@ -84,8 +84,8 @@ div.wikiEditor-ui .wikiEditor-ui-view {
 }
 
 div.wikiEditor-ui-toolbar {
-	background-color: var( --clr-surface-4 );
-	color: var( --clr-on-surface );
+	background-color: var( --clr-surface-4, #f8f9fa );
+	color: var( --clr-on-surface, #212529 );
 }
 
 div.wikiEditor-ui-toolbar .group .tool-select .options {
@@ -94,14 +94,14 @@ div.wikiEditor-ui-toolbar .group .tool-select .options {
 }
 
 .CodeMirror-activeline-background {
-	background-color: var( --clr-surface-1 );
+	background-color: var( --clr-surface-2, #e8f2ff );
 }
 
 .CodeMirror-linenumber {
 	cursor: pointer;
-	color: var( --clr-on-surface );
+	color: var( --clr-on-surface, #999999 );
 }
 
 .CodeMirror-gutters {
-	background-color: var( --clr-surface-1 );
+	background-color: var( --clr-surface-1, #f7f7f7 );
 }


### PR DESCRIPTION
Added:
- dark-theme alternatives for defined colors in mediawiki.css and codemirror.css
- CSS variables with fallbacks to CodeMirror ui elements.

Needs to be merged simultaneously with LakeSideView on GitLab: https://gitlab.com/teamliquid-dev/liquipedia/skins/lakesideview/-/merge_requests/10