### PR TITLE
LPA-7182 Default editor styling

### DIFF
--- a/resources/styles/codemirror.css
+++ b/resources/styles/codemirror.css
@@ -77,19 +77,10 @@
 	z-index: 10000;
 }
 
-div.wikiEditor-ui .wikiEditor-ui-view {
-	border-color: var( --clr-border, #c8ccd1 );
-}
-
 .CodeMirror.lineWrapping pre {
 	word-wrap: break-word;
 	white-space: pre-wrap;
 	word-break: normal;
-}
-
-div.wikiEditor-ui-toolbar {
-	background-color: var( --clr-surface-4, #f8f9fa );
-	color: var( --clr-on-surface, #212529 );
 }
 
 div.wikiEditor-ui-toolbar .group .tool-select .options {


### PR DESCRIPTION
https://app.clickup.com/t/10617282/LPA-7182

Removed css that is meant for the default editor.

To be deployed together with https://gitlab.com/teamliquid-dev/liquipedia/skins/lakesideview/-/merge_requests/24