### PR TITLE
Remove focus to make summary field clickable again

### DIFF
--- a/resources/scripts/codemirror.js
+++ b/resources/scripts/codemirror.js
@@ -268,7 +268,6 @@ if ( !String.prototype.includes ) {
 			}
 
 			const retval = fn[ command ].call( this, options );
-			codeMirror.focus();
 
 			return retval;
 		},


### PR DESCRIPTION
By removing this line the summary field is usable again. 
Not sure if it's the correct fix but it works for the time being.