### PR TITLE
Changing editing cursor color on dark theme

### DIFF
--- a/resources/styles/codemirror.css
+++ b/resources/styles/codemirror.css
@@ -114,3 +114,7 @@ div.wikiEditor-ui-toolbar .group .tool-select .options {
 .CodeMirror-line > span > span::selection {
 	background: var( --clr-surface-3, #d7d4f0 );
 }
+
+.theme--dark .CodeMirror-cursor {
+	border-color: var(--clr-on-background, #d7d4f0 );
+}

--- a/resources/styles/codemirror.css
+++ b/resources/styles/codemirror.css
@@ -116,5 +116,5 @@ div.wikiEditor-ui-toolbar .group .tool-select .options {
 }
 
 .theme--dark .CodeMirror-cursor {
-	border-color: var(--clr-on-background, #d7d4f0 );
+	border-color: var( --clr-on-background, #d7d4f0 );
 }


### PR DESCRIPTION
## Summary

The current editing cursor was still black and thus not really working for dark mode, this puts it as white.

## How did you test this change?

Tested on my dev environment [here](https://liquipedia.net/starcraft2/Main_Page)

## Note

[Gitlab ticket](https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/issues/60)
