### PR TITLE
change used js hook in attempt to better time loading of codemirror

### DIFF
--- a/resources/scripts/codemirror.js
+++ b/resources/scripts/codemirror.js
@@ -423,7 +423,7 @@ if ( !String.prototype.includes ) {
 		codeMirror = codeMirrorDesktop;
 	}
 	if ( codeMirror ) {
-		mw.hook( 'wikipage.editform' ).add( function() {
+		mw.hook( 'wikiEditor.toolbarReady' ).add( function() {
 			enableCodeMirror();
 
 			// define JQuery hook for searching and replacing text using


### PR DESCRIPTION
The new hook is also used by the MediaWiki codemirror extension that was the original inspiration of this different take on codemirror for MediaWiki: https://github.com/wikimedia/mediawiki-extensions-CodeMirror/blob/master/resources/ext.CodeMirror.WikiEditor.js#L373C13-L373C23