### PR TITLE
Improve readability of double underscore keywords in darkmode

### DIFF
--- a/cm-library/codemirror-mode/mediawiki/mediawiki.css
+++ b/cm-library/codemirror-mode/mediawiki/mediawiki.css
@@ -8,7 +8,7 @@
 
 .theme--dark .cm-mw-skipformatting { background-color: #00568f }
 .theme--dark .cm-mw-list { color: #52aeff; }
-.theme--dark .cm-mw-doubleUnderscore, .cm-mw-signature, .cm-mw-hr { color: #52aeff; background-color: var( --clr-surface-5 ); }
+.theme--dark .cm-mw-doubleUnderscore, .cm-mw-signature, .cm-mw-hr { color: #52aeff; background-color: var( --clr-surface-4 ); }
 .theme--dark .cm-mw-indenting { color: #52aeff; }
 .theme--dark .cm-mw-mnemonic { color: #2ccc00; }
 .theme--dark .cm-mw-comment { color: #94adad; }


### PR DESCRIPTION
Adjusts the background color of double underscore keywords to be a bit darker in darkmode.
Tested using dev tools.

Before:
![image](https://github.com/user-attachments/assets/c174b8af-d53a-4768-ad45-23f4c7db4dec)
After:
![image](https://github.com/user-attachments/assets/5b73c188-308b-440e-909a-6cc8bf04a74d)
