### PR TITLE
Update selection background-color for dark theme

### DIFF
--- a/resources/styles/codemirror.css
+++ b/resources/styles/codemirror.css
@@ -92,6 +92,10 @@ div.wikiEditor-ui-toolbar .group .tool-select .options {
 	background-color: var( --clr-surface-3, #e8f2ff );
 }
 
+.theme--dark .CodeMirror-activeline-background {
+	background-color: #3a3a3a;
+}
+
 .CodeMirror-linenumber {
 	cursor: pointer;
 	color: var( --clr-on-surface, #999999 );
@@ -105,8 +109,16 @@ div.wikiEditor-ui-toolbar .group .tool-select .options {
 	background: var( --clr-surface-3, #d9d9d9 );
 }
 
+.theme--dark .CodeMirror-selected {
+	background: #3a3a3a;
+}
+
 .CodeMirror-focused .CodeMirror-selected {
 	background: var( --clr-surface-3, #d7d4f0 );
+}
+
+.theme--dark .CodeMirror-focused .CodeMirror-selected {
+	background: #3a3a3a;
 }
 
 .CodeMirror-line::selection,


### PR DESCRIPTION
Update the selection background-color with something more readable/noticable. The surface color variable didn't offer enough contrast so I picked something else and tested in a contrast checker, so it's WCAG AAA approved.

Before:
![image](https://github.com/user-attachments/assets/b4798004-1658-470b-998a-70d8ce8ff299)


After:
![image](https://github.com/user-attachments/assets/d9ba8202-11d9-4a16-a566-52c021f3e1b1)


Closes:
https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/issues/148